### PR TITLE
Fix error changing ownership when deleting a user, if the current user has temporary credentials

### DIFF
--- a/redshift/resource_redshift_user_test.go
+++ b/redshift/resource_redshift_user_test.go
@@ -271,3 +271,16 @@ resource "redshift_user" "user_superuser" {
   password = "FooBarBaz123"
 }
 `
+
+func TestPermanentUsername(t *testing.T) {
+	expected := "user"
+	if result := permanentUsername(expected); result != expected {
+		t.Fatalf("Calling permanentUsername on a non-prefixed username should return the username. Expected %s but was %s", expected, result)
+	}
+	if result := permanentUsername(fmt.Sprintf("IAM:%s", expected)); result != expected {
+		t.Fatalf("permanentUsername should strip \"IAM:\" prefix. Expected %s but was %s", expected, result)
+	}
+	if result := permanentUsername(fmt.Sprintf("IAMA:%s", expected)); result != expected {
+		t.Fatalf("permanentUsername should strip \"IAMA:\" prefix. Expected %s but was %s", expected, result)
+	}
+}


### PR DESCRIPTION
When deleting a user, the provider attempts to chown all of the user's objects to `$REDSHIFT_USER`. If you use temporary credentials provided by [GetClusterCredentials](https://docs.aws.amazon.com/redshift/latest/APIReference/API_GetClusterCredentials.html) the username you need to authenticate as is prefixed with either `IAM:` or `IAMA:`. However, the username needed for the chown is the non-prefixed one.

This PR fixes the issue by stripping these specific prefixes from the chown statements (and also parameterizes them).

You can reproduce the error like so:

```bash
username=<your db username>
clusterIdentifier=<redshift cluster identifier>
credentials="$(aws redshift get-cluster-credentials --db-user=$username --cluster-identifier=$clusterIdentifier)"

# This assumes you have jq on your PATH. otherwise just "echo $credentials" and set the values explicitly
export REDSHIFT_USER="$(echo $credentials | jq -r .DbUser)"
export REDSHIFT_PASSWORD="$(echo $credentials | jq -r .DbPassword)"

make testacc
```

Note: while this PR is in a similar vein to #3 the underlying issue isn't necessarily dependent upon the changes there. 