### PR TITLE
Use md5 hashing for redshift_user passwords

### DIFF
--- a/redshift/config.go
+++ b/redshift/config.go
@@ -131,3 +131,9 @@ func (c *Config) Client() (*Client, error) {
 
 	return &client, nil
 }
+
+func (c *Client) Close() {
+	if c.db != nil {
+		c.db.Close()
+	}
+}


### PR DESCRIPTION
Per https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html:
>As a more secure alternative to passing the CREATE USER password parameter as clear text, you can specify an MD5 hash of a string that includes the password and user name.
>
>**Note**
>When you specify an MD5 hash string, the CREATE USER command checks for a valid MD5 hash string, but it doesn't validate the password portion of the string. It is possible in this case to create a password, such as an empty string, that you can't use to log on to the database.
>
>To specify an MD5 password, follow these steps:
>
>1. Concatenate the password and user name.
>For example, for password `ez` and user `user1`, the concatenated string is `ezuser1`.
>
>2. Convert the concatenated string into a 32-character MD5 hash string. You can use any MD5 utility to create the hash string. The following example uses the Amazon Redshift [MD5 function](https://docs.aws.amazon.com/redshift/latest/dg/r_MD5.html) and the concatenation operator ( || ) to return a 32-character MD5-hash string.
>```sql
>select md5('ez' || 'user1');
>md5                             
>--------------------------------
>153c434b4b77c89e6b94f12c5393af5b
>```
>
>3. Concatenate `'md5'` in front of the MD5 hash string and provide the concatenated string as the *md5hash* argument.
>```sql
>create user user1 password 'md5153c434b4b77c89e6b94f12c5393af5b';
>```
>4. Log on to the database using the user name and password.
>For this example, log on as `user1` with password `ez`.