### PR TITLE
Fix typo `provider.go`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ provider "redshift" {
 
 Required:
 
-- **cluster_identifier** (String) The unique identifier of the cluster that contains the database for which your are requesting credentials. This parameter is case sensitive.
+- **cluster_identifier** (String) The unique identifier of the cluster that contains the database for which you are requesting credentials. This parameter is case sensitive.
 
 Optional:
 

--- a/redshift/provider.go
+++ b/redshift/provider.go
@@ -85,7 +85,7 @@ func Provider() *schema.Provider {
 						"cluster_identifier": {
 							Type:         schema.TypeString,
 							Required:     true,
-							Description:  "The unique identifier of the cluster that contains the database for which your are requesting credentials. This parameter is case sensitive.",
+							Description:  "The unique identifier of the cluster that contains the database for which you are requesting credentials. This parameter is case sensitive.",
 							ValidateFunc: validation.StringLenBetween(1, 2147483647),
 						},
 						"auto_create_user": {


### PR DESCRIPTION
Fixed typo in ` redshift/provider.go`: changed from `your` to `you` in line 88.