### PR TITLE
Avoid some bugs in reading group privileges from Redshift

### DIFF
--- a/redshift/resource_redshift_grant.go
+++ b/redshift/resource_redshift_grant.go
@@ -242,11 +242,11 @@ func readGroupTableGrants(db *DBConnection, d *schema.ResourceData) error {
 	query := `
   SELECT
     relname,
-    decode(charindex('r',split_part(split_part(array_to_string(relacl, '|'),gr.groname,2 ) ,'/',1)), 0,0,1) as select,
-    decode(charindex('w',split_part(split_part(array_to_string(relacl, '|'),gr.groname,2 ) ,'/',1)), 0,0,1) as update,
-    decode(charindex('a',split_part(split_part(array_to_string(relacl, '|'),gr.groname,2 ) ,'/',1)), 0,0,1) as insert,
-    decode(charindex('d',split_part(split_part(array_to_string(relacl, '|'),gr.groname,2 ) ,'/',1)), 0,0,1) as delete,
-    decode(charindex('x',split_part(split_part(array_to_string(relacl, '|'),gr.groname,2 ) ,'/',1)), 0,0,1) as references
+    decode(charindex('r',split_part(split_part(array_to_string(relacl, '|'), 'group ' + gr.groname,2 ) ,'/',1)), 0,0,1) as select,
+    decode(charindex('w',split_part(split_part(array_to_string(relacl, '|'),'group ' + gr.groname,2 ) ,'/',1)), 0,0,1) as update,
+    decode(charindex('a',split_part(split_part(array_to_string(relacl, '|'), 'group ' + gr.groname,2 ) ,'/',1)), 0,0,1) as insert,
+    decode(charindex('d',split_part(split_part(array_to_string(relacl, '|'), 'group ' + gr.groname,2 ) ,'/',1)), 0,0,1) as delete,
+    decode(charindex('x',split_part(split_part(array_to_string(relacl, '|'), 'group ' + gr.groname,2 ) ,'/',1)), 0,0,1) as references
   FROM pg_group gr, pg_class cl
   JOIN pg_namespace nsp ON nsp.oid = cl.relnamespace
   WHERE


### PR DESCRIPTION
Avoid some bugs in reading group privileges from Redshift when identically named users and groups exist. 

This fixes some, but not all of the possible issues highlighted in https://github.com/brainly/terraform-provider-redshift/issues/24 