### PR TITLE
Deprecate redshift_privilege resource

### DIFF
--- a/redshift/resource_redshift_privilege.go
+++ b/redshift/resource_redshift_privilege.go
@@ -32,6 +32,9 @@ var objectTypesCodes = map[string]string{
 
 func redshiftPrivilege() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: `
+		This resource is deprecated, might have bugs and may not be working as expected. Please use redshift_grant and redshift_default_privilege instead.
+`,
 		Description: `
 When you create a database object, you are its owner. By default, only a superuser or the owner of an object can query, modify, or grant privileges on the object. For users to use an object, you must grant the necessary privileges to the user or the group that contains the user. Database superusers have the same privileges as database owners.
 `,


### PR DESCRIPTION
`redshift_privilege` is buggy and has been superseded by `redshift_grant` + `redshift_default_privilege`. This PR adds a deprecation message to the resource. 