### PR TITLE
Move the superuser/password validation to CustomizeDiff func

### DIFF
--- a/redshift/resource_redshift_user_test.go
+++ b/redshift/resource_redshift_user_test.go
@@ -201,7 +201,28 @@ resource "redshift_user" "superuser" {
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile("\"superuser\": all of `password,superuser` must be specified"),
+				ExpectError: regexp.MustCompile("Users that are superusers must define a password."),
+			},
+		},
+	})
+}
+
+func TestAccRedshiftUser_SuperuserFalseDoesntRequiresPassword(t *testing.T) {
+	userName := strings.ReplaceAll(acctest.RandomWithPrefix("tf_acc_superuser"), "-", "_")
+	config := fmt.Sprintf(`
+resource "redshift_user" "superuser" {
+  name = %[1]q
+  superuser = false
+}
+`, userName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRedshiftUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
 			},
 		},
 	})


### PR DESCRIPTION
Found as a tip in the Terraform community forums, that you can use the `CustomizeDiff` function to validate related attributes on the plan phase. The drawback is that this will not be picked by `terraform validate` but still better than this being errored at apply phase.