### PR TITLE
Remove CASCADE from ALTER DEFAULT when dropping users and groups

### DIFF
--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -158,7 +158,7 @@ func resourceRedshiftGroupDelete(db *DBConnection, d *schema.ResourceData) error
 		if _, err := tx.Exec(fmt.Sprintf("REVOKE ALL ON ALL TABLES IN SCHEMA %s FROM GROUP %s", pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(groupName))); err != nil {
 			return err
 		}
-		if _, err := tx.Exec(fmt.Sprintf("ALTER DEFAULT PRIVILEGES IN SCHEMA %s REVOKE ALL ON TABLES FROM GROUP %s CASCADE", pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(groupName))); err != nil {
+		if _, err := tx.Exec(fmt.Sprintf("ALTER DEFAULT PRIVILEGES IN SCHEMA %s REVOKE ALL ON TABLES FROM GROUP %s", pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(groupName))); err != nil {
 			return err
 		}
 	}

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -400,7 +400,7 @@ func resourceRedshiftUserDelete(db *DBConnection, d *schema.ResourceData) error 
 			return err
 		}
 
-		if _, err := tx.Exec(fmt.Sprintf("ALTER DEFAULT PRIVILEGES IN SCHEMA %s REVOKE ALL ON TABLES FROM %s CASCADE", pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(userName))); err != nil {
+		if _, err := tx.Exec(fmt.Sprintf("ALTER DEFAULT PRIVILEGES IN SCHEMA %s REVOKE ALL ON TABLES FROM %s", pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(userName))); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
AWS Redshift recently released a Role-based Access Control(RBAC) feature, which simplifies the managing of security privileges with Amazon Redshift.
RBAC doesn't support CASCADE parameter when modifying privileges by using REVOKE and ALTER DEFAULT PRIVILEGES.