### PR TITLE
Fix typo in code - wrong variable referenced

### DIFF
--- a/redshift/resource_redshift_default_privileges.go
+++ b/redshift/resource_redshift_default_privileges.go
@@ -226,7 +226,7 @@ func readGroupTableDefaultPrivileges(tx *sql.Tx, d *schema.ResourceData, groupID
 	appendIfTrue(tableUpdate, "update", &privileges)
 	appendIfTrue(tableInsert, "insert", &privileges)
 	appendIfTrue(tableDelete, "delete", &privileges)
-	appendIfTrue(tableDelete, "drop", &privileges)
+	appendIfTrue(tableDrop, "drop", &privileges)
 	appendIfTrue(tableReferences, "references", &privileges)
 
 	log.Printf("[DEBUG] Collected privileges for group ID %d: %v\n", groupID, privileges)


### PR DESCRIPTION
This caused permanent diff in case default privilege objection contained DELETE grant. Also it would be not able to detect drift in DROP privilege.