### PR TITLE
`user`: handle unknown superuser passwords

### DIFF
--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -57,8 +57,10 @@ Amazon Redshift user accounts can only be created and dropped by a database supe
 		},
 		CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, p interface{}) error {
 			isSuperuser := d.Get(userSuperuserAttr).(bool)
+			isPasswordKnown := d.NewValueKnown(userPasswordAttr)
+
 			password, hasPassword := d.GetOk(userPasswordAttr)
-			if isSuperuser && (!hasPassword || password.(string) == "") {
+			if isSuperuser && isPasswordKnown && (!hasPassword || password.(string) == "") {
 				return fmt.Errorf("Users that are superusers must define a password.")
 			}
 


### PR DESCRIPTION
Currently, it's not possible to define configuration like this:

```tf
resource "redshift_user" "terraform" {
  name      = "terraform"
  superuser = true
  password  = random_password.terraform.result
}

resource "random_password" "terraform" {
  length      = 64
  min_lower   = 1
  min_upper   = 1
  min_numeric = 1
}
```

Given this configuration, the provider returns an error:

```
Users that are superusers must define a password.
```

Upon further investigation, this error is returned from `CustomizeDiff`. This hook runs before a plan is rendered. This means that on first run, before the `Create` method for `random_password` has run, the value for `result` is not yet known.

`GetOk` will still return `_, true`, because it is known that some value is set. When the value is unknown, `Get` will return the zero value. Any plan time inspection can only occur when the new value is known at plan time. 

While I didn't set up real cluster credentials to run the acceptance tests to success for this, I did execute them to ensure that the added test case fails with the original error and proceeds to a connection error with the fix.