### PR TITLE
Add `region` support when calling `GetClusterCredentials`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,7 @@ Optional:
 - **auto_create_user** (Boolean) Create a database user with the name specified for the user if one does not exist.
 - **db_groups** (Set of String) A list of the names of existing database groups that the user will join for the current session, in addition to any group memberships for an existing user. If not specified, a new user is added only to PUBLIC.
 - **duration_seconds** (Number) The number of seconds until the returned temporary password expires.
+- **region** (String) The AWS region where the Redshift cluster is located.
 
 <a id="nestedblock--temporary_credentials--assume_role"></a>
 ### Nested Schema for `temporary_credentials.assume_role`

--- a/redshift/provider.go
+++ b/redshift/provider.go
@@ -93,6 +93,11 @@ func Provider() *schema.Provider {
 							Description:  "The unique identifier of the cluster that contains the database for which you are requesting credentials. This parameter is case sensitive.",
 							ValidateFunc: validation.StringLenBetween(1, 2147483647),
 						},
+						"region": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The AWS region where the Redshift cluster is located.",
+						},
 						"auto_create_user": {
 							Type:        schema.TypeBool,
 							Optional:    true,
@@ -231,6 +236,11 @@ func redshiftSdkClient(d *schema.ResourceData) (*redshift.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if region := d.Get("temporary_credentials.0.region").(string); region != "" {
+		cfg.Region = region
+	}
+
 	if _, ok := d.GetOk("temporary_credentials.0.assume_role"); ok {
 		var parsedRoleArn string
 		if roleArn, ok := d.GetOk("temporary_credentials.0.assume_role.0.arn"); ok {


### PR DESCRIPTION
When calling `GetClusterCredentials`, users must supply the region where the Redshift cluster is located. Currently, there is no explicit provider configuration field for this input. As noted in https://github.com/brainly/terraform-provider-redshift/issues/58#issuecomment-1060708054, you can use `AWS_REGION` to set this.

I checked the AWS provider and mirrored its simple field implementation, with no validation:

https://github.com/hashicorp/terraform-provider-aws/blob/19469514cc16736d80ab976aa3178d5aaedbeba8/internal/provider/provider.go#L292-L297