### PR TITLE
Preserve user names case in group membership list and database owner attribute

### DIFF
--- a/redshift/resource_redshift_database.go
+++ b/redshift/resource_redshift_database.go
@@ -46,9 +46,6 @@ func redshiftDatabase() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "Owner of the database, usually the user who created it",
-				StateFunc: func(val interface{}) string {
-					return strings.ToLower(val.(string))
-				},
 			},
 			databaseConnLimitAttr: {
 				Type:         schema.TypeInt,

--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -47,9 +47,6 @@ Groups are collections of users who are all granted whatever privileges are asso
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
-					StateFunc: func(val interface{}) string {
-						return strings.ToLower(val.(string))
-					},
 				},
 				Description: "List of the user names to add to the group",
 			},


### PR DESCRIPTION
Continuation of #67 