### PR TITLE
allow superusers to have unmanaged passwords

### DIFF
--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -55,17 +55,6 @@ Amazon Redshift user accounts can only be created and dropped by a database supe
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, p interface{}) error {
-			isSuperuser := d.Get(userSuperuserAttr).(bool)
-			isPasswordKnown := d.NewValueKnown(userPasswordAttr)
-
-			password, hasPassword := d.GetOk(userPasswordAttr)
-			if isSuperuser && isPasswordKnown && (!hasPassword || password.(string) == "") {
-				return fmt.Errorf("Users that are superusers must define a password.")
-			}
-
-			return nil
-		},
 
 		Schema: map[string]*schema.Schema{
 			userNameAttr: {


### PR DESCRIPTION
This will remove the check for empty passwords for superusers, which will allow managing passwords outside of TF, but will fail at the apply stage if trying to create a superuser with no password - instead of at the plan stage as this does.