### PR TITLE
Fix readSchemaGrants and readTableGrants for groups

### DIFF
--- a/redshift/resource_redshift_grant.go
+++ b/redshift/resource_redshift_grant.go
@@ -267,8 +267,8 @@ func readSchemaGrants(db *DBConnection, d *schema.ResourceData) error {
 		entityName = d.Get(grantGroupAttr).(string)
 		query = `
   SELECT
-    decode(charindex('C',split_part(split_part(array_to_string(ns.nspacl, '|'),'group ' || gr.groname,2 ) ,'/',1)), 0,0,1) as create,
-    decode(charindex('U',split_part(split_part(array_to_string(ns.nspacl, '|'),'group ' || gr.groname,2 ) ,'/',1)), 0,0,1) as usage
+    decode(charindex('C',split_part(split_part(array_to_string(ns.nspacl, '|'),'group ' || gr.groname || '=',2 ) ,'/',1)), 0,0,1) as create,
+    decode(charindex('U',split_part(split_part(array_to_string(ns.nspacl, '|'),'group ' || gr.groname || '=',2 ) ,'/',1)), 0,0,1) as usage
   FROM pg_namespace ns, pg_group gr
   WHERE
     ns.nspname=$1 
@@ -320,14 +320,14 @@ func readTableGrants(db *DBConnection, d *schema.ResourceData) error {
 		query = `
   SELECT
     relname,
-    decode(charindex('r',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname,2 ) ,'/',1)), null,0, 0,0, 1) as select,
-    decode(charindex('w',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname,2 ) ,'/',1)), null,0, 0,0, 1) as update,
-    decode(charindex('a',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname,2 ) ,'/',1)), null,0, 0,0, 1) as insert,
-    decode(charindex('d',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname,2 ) ,'/',1)), null,0, 0,0, 1) as delete,
-    decode(charindex('D',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname,2 ) ,'/',1)), null,0, 0,0, 1) as drop,
-    decode(charindex('x',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname,2 ) ,'/',1)), null,0, 0,0, 1) as references,
-    decode(charindex('R',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname,2 ) ,'/',1)), null,0, 0,0, 1) as rule,
-    decode(charindex('t',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname,2 ) ,'/',1)), null,0, 0,0, 1) as trigger
+    decode(charindex('r',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname || '=',2 ) ,'/',1)), null,0, 0,0, 1) as select,
+    decode(charindex('w',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname || '=',2 ) ,'/',1)), null,0, 0,0, 1) as update,
+    decode(charindex('a',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname || '=',2 ) ,'/',1)), null,0, 0,0, 1) as insert,
+    decode(charindex('d',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname || '=',2 ) ,'/',1)), null,0, 0,0, 1) as delete,
+    decode(charindex('D',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname || '=',2 ) ,'/',1)), null,0, 0,0, 1) as drop,
+    decode(charindex('x',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname || '=',2 ) ,'/',1)), null,0, 0,0, 1) as references,
+    decode(charindex('R',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname || '=',2 ) ,'/',1)), null,0, 0,0, 1) as rule,
+    decode(charindex('t',split_part(split_part(array_to_string(relacl, '|'),'group ' || gr.groname || '=',2 ) ,'/',1)), null,0, 0,0, 1) as trigger
   FROM pg_group gr, pg_class cl
   JOIN pg_namespace nsp ON nsp.oid = cl.relnamespace
   WHERE


### PR DESCRIPTION
This PR fixed the readSchemaGrants and readTableGrants functions. They currently don't work correctly if two groups start with the same name and have different permissions: in our case, we have a `data` group and a `data_eng` legacy group and the queries were returning the privileges for the `data_eng` group, even when `gr.groname == data`.