### PR TITLE
Improve docs for redshift_datashare_privilege resource

### DIFF
--- a/docs/resources/datashare_privilege.md
+++ b/docs/resources/datashare_privilege.md
@@ -30,16 +30,16 @@ resource "redshift_datashare" "share" {
 
 # Example: datashare permission in same account
 resource "redshift_datashare_privilege" "within_account" {
-  name = redshift_datashare.share.name # Required
-  namespace = "d34dbe3f-d34d-b33f-d3ad-b33fd34db33f" # Required
+  share_name = redshift_datashare.share.name          # Required
+  namespace  = "d34dbe3f-d34d-b33f-d3ad-b33fd34db33f" # Required
 }
 
 # Example: cross-account datashare permission.
 # Note: you will also need to authorize the cross-account datashare
 # in the AWS console after creating this resource
-resource "redshift_datashare_privilege" "within_account" {
-  name = redshift_datashare.share.name # Required
-  account = "123456789012" # Required
+resource "redshift_datashare_privilege" "cross_account" {
+  share_name = redshift_datashare.share.name # Required
+  account    = "123456789012"                # Required
 }
 ```
 

--- a/examples/resources/redshift_datashare_privilege/resource.tf
+++ b/examples/resources/redshift_datashare_privilege/resource.tf
@@ -4,14 +4,14 @@ resource "redshift_datashare" "share" {
 
 # Example: datashare permission in same account
 resource "redshift_datashare_privilege" "within_account" {
-  name = redshift_datashare.share.name # Required
-  namespace = "d34dbe3f-d34d-b33f-d3ad-b33fd34db33f" # Required
+  share_name = redshift_datashare.share.name          # Required
+  namespace  = "d34dbe3f-d34d-b33f-d3ad-b33fd34db33f" # Required
 }
 
 # Example: cross-account datashare permission.
 # Note: you will also need to authorize the cross-account datashare
 # in the AWS console after creating this resource
-resource "redshift_datashare_privilege" "within_account" {
-  name = redshift_datashare.share.name # Required
-  account = "123456789012" # Required
+resource "redshift_datashare_privilege" "cross_account" {
+  share_name = redshift_datashare.share.name # Required
+  account    = "123456789012"                # Required
 }


### PR DESCRIPTION
Changes:
 * rename within_account to cross_account for cross-account datashare permission example
 * "terraform fmt" examples
 * rename "name" to "share_name"