### PR TITLE
Fix checkUserExists functions

### DIFF
--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -213,7 +213,7 @@ func setGroupName(tx *sql.Tx, d *schema.ResourceData) error {
 func checkIfUserExists(tx *sql.Tx, name string) (bool, error) {
 
 	var result int
-	err := tx.QueryRow("SELECT 1 from pg_user_info WHERE usename=$1", name).Scan(&result)
+	err := tx.QueryRow("SELECT 1 from pg_user_info WHERE usename='$1'", name).Scan(&result)
 
 	switch err {
 	case sql.ErrNoRows:

--- a/redshift/resource_redshift_user_test.go
+++ b/redshift/resource_redshift_user_test.go
@@ -330,7 +330,7 @@ func checkUserExists(client *Client, user string) (bool, error) {
 		return false, err
 	}
 	var _rez int
-	err = db.QueryRow("SELECT 1 from pg_user_info WHERE usename=$1", user).Scan(&_rez)
+	err = db.QueryRow("SELECT 1 from pg_user_info WHERE usename='$1'", user).Scan(&_rez)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil


### PR DESCRIPTION
This PR fixes an issue that occurs when removing an existing user from a group.
The error occurs during the `terraform apply` phase, the error that gets thrown is the following:

```
│ Error: error reading info about user: %!s(<nil>)
│
│   with module.groups["group_name"].redshift_group.group,
│   on ../../modules/group/main.tf line 1, in resource "redshift_group" "group":
│    1: resource "redshift_group" "group" {
``` 

Currently, the query used to check for the existence of a user is: `SELECT 1 from pg_user_info WHERE usename=$1`

The issue is that the `usename` is not enclosed in single quotes `''`, when _manually_ executed this query causes redshift to return the following error:
```
db=# SELECT 1 from pg_user_info WHERE usename=existinguser;
ERROR:  column "existinguser" does not exist in pg_user_info
```

The same query executed with the `usename` enclosed in quotes returns the correct result:
```
db=# SELECT 1 from pg_user_info WHERE usename='existinguser';
?column?
----------
        1
(1 row)
```