### PR TITLE
Fix removing existing users from groups

### DIFF
--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -215,10 +215,10 @@ func checkIfUserExists(tx *sql.Tx, name string) (bool, error) {
 	var result int
 	err := tx.QueryRow("SELECT 1 from pg_user_info WHERE usename=$1", name).Scan(&result)
 
-	switch err {
-	case sql.ErrNoRows:
+	switch {
+	case err == sql.ErrNoRows:
 		return false, nil
-	case nil:
+	case err != nil:
 		return false, fmt.Errorf("error reading info about user: %s", err)
 	}
 


### PR DESCRIPTION
A fix to allow removing existing users from groups.

The added test case replicates an error reported by @tripolif98 in #79. 

```
=== RUN   TestAccRedshiftGroup_RemoveExistingUser
    resource_redshift_group_test.go:145: Step 2/2 error: Error running apply: exit status 1

        Error: error reading info about user: %!s(<nil>)

          with redshift_group.group,
          on terraform_plugin_test.tf line 2, in resource "redshift_group" "group":
           2: resource "redshift_group" "group" {

--- FAIL: TestAccRedshiftGroup_RemoveExistingUser (13.19s)
FAIL
FAIL    github.com/brainly/terraform-provider-redshift/redshift 13.200s
FAIL
```
After fix to the `switch` statement is applied, the test passes.
```
=== RUN   TestAccRedshiftGroup_RemoveExistingUser
--- PASS: TestAccRedshiftGroup_RemoveExistingUser (16.52s)
PASS
ok      github.com/brainly/terraform-provider-redshift/redshift 16.522s
```