### PR TITLE
feature/redshift serverless support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ provider "redshift" {
 
 - **database** (String) The name of the database to connect to. The default is `redshift`.
 - **host** (String) Name of Redshift server address to connect to.
+- **is_serverless** (Boolean) Flag if redshift is serverless.
 - **max_connections** (Number) Maximum number of connections to establish to the database. Zero means unlimited.
 - **password** (String, Sensitive) Password to be used if the Redshift server demands password authentication.
 - **port** (Number) The Redshift port number to connect to at the server host.

--- a/redshift/config.go
+++ b/redshift/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Database string
 	SSLMode  string
 	MaxConns int
+	IsServerless bool
 }
 
 // Client struct holding connection string

--- a/redshift/provider.go
+++ b/redshift/provider.go
@@ -125,6 +125,12 @@ func Provider() *schema.Provider {
 					},
 				},
 			},
+			"is_serverless": {
+				Type:        schema.TypeBool,
+				Description: "Flag if redshift is serverless.",
+				Optional:    true,
+				Default:     false,
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"redshift_user":                redshiftUser(),
@@ -160,6 +166,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Database: d.Get("database").(string),
 		SSLMode:  d.Get("sslmode").(string),
 		MaxConns: d.Get("max_connections").(int),
+		IsServerless: d.Get("is_serverless").(bool),
 	}
 
 	log.Println("[DEBUG] creating database client")


### PR DESCRIPTION
Add redshift serverless support to resolve `svv_schema_quota_state` and `svl_user_info` access restrictions.