### PR TITLE
support md5 password in terraform code

### DIFF
--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -197,7 +197,11 @@ func resourceRedshiftUserCreate(db *DBConnection, d *schema.ResourceData) error 
 		if val != "" {
 			switch {
 			case opt.hclKey == userPasswordAttr:
-				createOpts = append(createOpts, fmt.Sprintf("%s '%s'", opt.sqlKey, md5Password(userName, val)))
+				if strings.HasPrefix(val, "md5") {
+					createOpts = append(createOpts, fmt.Sprintf("%s '%s'", opt.sqlKey, pqQuoteLiteral(val)))
+				} else {
+					createOpts = append(createOpts, fmt.Sprintf("%s '%s'", opt.sqlKey, md5Password(userName, val)))
+				}
 			case opt.hclKey == userValidUntilAttr:
 				switch {
 				case v.(string) == "", strings.ToLower(v.(string)) == "infinity":


### PR DESCRIPTION
Currently we put the plain text password to the terraform code and it will be hashed by md5 (username + password). 
https://github.com/brainly/terraform-provider-redshift/pull/7

However, this feature removed the ability to use an md5 hash in the password field.

This MR allow user to put an md5 hashed password to prevent putting plain-text password in terraform code.

