### PR TITLE
Fix userSessionTimeoutAttr condition

### DIFF
--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -224,7 +224,9 @@ func resourceRedshiftUserCreate(db *DBConnection, d *schema.ResourceData) error 
 
 	for _, opt := range intOpts {
 		val := d.Get(opt.hclKey).(int)
-		if opt.hclKey != userSessionTimeoutAttr && val != 0 {
+		if opt.hclKey == userSessionTimeoutAttr && val != 0 {
+			createOpts = append(createOpts, fmt.Sprintf("%s %d", opt.sqlKey, val))
+		} else if opt.hclKey != userSessionTimeoutAttr {
 			createOpts = append(createOpts, fmt.Sprintf("%s %d", opt.sqlKey, val))
 		}
 	}


### PR DESCRIPTION
This PR fixes condition of userSessionTimeoutAttr that results with skipping session timeout parameter during user creation. 