### PR TITLE
Implement GRANT TO PUBLIC for all supported object types

### DIFF
--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -38,8 +38,7 @@ resource "redshift_grant" "user" {
 
 # Granting permission to PUBLIC (GRANT ... TO PUBLIC)
 resource "redshift_grant" "public" {
-  group = "public" // "public" here indicates we want grant TO PUBLIC, not "public" group.
-
+  group       = "public" // "public" or "PUBLIC" (it is case insensitive for this case) here indicates we want grant TO PUBLIC, not "public" group which cannot even be created in Redshift (keyword).
   schema      = "my_schema"
   object_type = "schema"
   privileges  = ["usage"]
@@ -56,7 +55,7 @@ resource "redshift_grant" "public" {
 
 ### Optional
 
-- **group** (String) The name of the group to grant privileges on. Either `group` or `user` parameter must be set. Settings the group name to `public` will result in a `GRANT ... TO PUBLIC` statement.
+- **group** (String) The name of the group to grant privileges on. Either `group` or `user` parameter must be set. Settings the group name to `public` or `PUBLIC` (it is case insensitive in this case) will result in a `GRANT ... TO PUBLIC` statement.
 - **id** (String) The ID of this resource.
 - **objects** (Set of String) The objects upon which to grant the privileges. An empty list (the default) means to grant permissions on all objects of the specified type. Ignored when `object_type` is one of (`database`, `schema`).
 - **schema** (String) The database schema to grant privileges on.

--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -28,13 +28,21 @@ resource "redshift_grant" "group" {
 }
 
 # Granting permissions to execute functions or procedures requires providing their arguments' types
-
 resource "redshift_grant" "user" {
   user        = "john"
   schema      = "my_schema"
   object_type = "function"
   objects     = ["my_function(float)"]
   privileges  = ["execute"]
+}
+
+# Granting permission to PUBLIC (GRANT ... TO PUBLIC)
+resource "redshift_grant" "public" {
+  group = "public" // "public" here indicates we want grant TO PUBLIC, not "public" group.
+
+  schema      = "my_schema"
+  object_type = "schema"
+  privileges  = ["usage"]
 }
 ```
 
@@ -48,7 +56,7 @@ resource "redshift_grant" "user" {
 
 ### Optional
 
-- **group** (String) The name of the group to grant privileges on. Either `group` or `user` parameter must be set.
+- **group** (String) The name of the group to grant privileges on. Either `group` or `user` parameter must be set. Settings the group name to `public` will result in a `GRANT ... TO PUBLIC` statement.
 - **id** (String) The ID of this resource.
 - **objects** (Set of String) The objects upon which to grant the privileges. An empty list (the default) means to grant permissions on all objects of the specified type. Ignored when `object_type` is one of (`database`, `schema`).
 - **schema** (String) The database schema to grant privileges on.

--- a/examples/resources/redshift_grant/resource.tf
+++ b/examples/resources/redshift_grant/resource.tf
@@ -13,11 +13,19 @@ resource "redshift_grant" "group" {
 }
 
 # Granting permissions to execute functions or procedures requires providing their arguments' types
-
 resource "redshift_grant" "user" {
   user        = "john"
   schema      = "my_schema"
   object_type = "function"
   objects     = ["my_function(float)"]
   privileges  = ["execute"]
+}
+
+# Granting permission to PUBLIC (GRANT ... TO PUBLIC)
+resource "redshift_grant" "public" {
+  group = "public" // "public" here indicates we want grant TO PUBLIC, not "public" group.
+
+  schema      = "my_schema"
+  object_type = "schema"
+  privileges  = ["usage"]
 }

--- a/examples/resources/redshift_grant/resource.tf
+++ b/examples/resources/redshift_grant/resource.tf
@@ -23,8 +23,7 @@ resource "redshift_grant" "user" {
 
 # Granting permission to PUBLIC (GRANT ... TO PUBLIC)
 resource "redshift_grant" "public" {
-  group = "public" // "public" here indicates we want grant TO PUBLIC, not "public" group.
-
+  group       = "public" // "public" or "PUBLIC" (it is case insensitive for this case) here indicates we want grant TO PUBLIC, not "public" group which cannot even be created in Redshift (keyword).
   schema      = "my_schema"
   object_type = "schema"
   privileges  = ["usage"]

--- a/redshift/data_source_redshift_schema_test.go
+++ b/redshift/data_source_redshift_schema_test.go
@@ -43,8 +43,9 @@ data "redshift_schema" "schema" {
 
 // Acceptance test for external redshift schema using AWS Glue Data Catalog
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_DATA_CATALOG_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_DATA_CATALOG_IAM_ROLE_ARNS - comma-separated list of ARNs to use
 func TestAccDataSourceRedshiftSchema_ExternalDataCatalog(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE", t)
 	iamRoleArnsRaw := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_IAM_ROLE_ARNS", t)
@@ -95,11 +96,14 @@ data "redshift_schema" "spectrum" {
 
 // Acceptance test for external redshift schema using Hive metastore
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME - hive metastore database endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME - hive metastore database endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_PORT - hive metastore port. Default is 9083
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_PORT - hive metastore port. Default is 9083
 func TestAccDataSourceRedshiftSchema_ExternalHive(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME", t)
@@ -159,13 +163,16 @@ data "redshift_schema" "hive" {
 
 // Acceptance test for external redshift schema using RDS Postgres
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME - RDS endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_IAM_ROLE_ARNS - comma-separated list of ARNs to use
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME - RDS endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_PORT - RDS port. Default is 5432
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SCHEMA - source database schema. Default is "public"
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_PORT - RDS port. Default is 5432
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SCHEMA - source database schema. Default is "public"
 func TestAccDataSourceRedshiftSchema_ExternalRdsPostgres(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME", t)
@@ -234,12 +241,15 @@ data "redshift_schema" "postgres" {
 
 // Acceptance test for external redshift schema using RDS Mysql
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME - RDS endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_IAM_ROLE_ARNS - comma-separated list of ARNs to use
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME - RDS endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_PORT - RDS port. Default is 3306
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_PORT - RDS port. Default is 3306
 func TestAccDataSourceRedshiftSchema_ExternalRdsMysql(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME", t)
@@ -302,9 +312,12 @@ data "redshift_schema" "mysql" {
 
 // Acceptance test for external redshift schema using datashare database
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE - source database name
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE - source database name
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA - datashare schema name. Default is "public"
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA - datashare schema name. Default is "public"
 func TestAccDataSourceRedshiftSchema_ExternalRedshift(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE", t)
 	dbSchema := os.Getenv("REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA")

--- a/redshift/resource_redshift_grant.go
+++ b/redshift/resource_redshift_grant.go
@@ -447,8 +447,9 @@ func readTableGrants(db *DBConnection, d *schema.ResourceData) error {
 			d.Set(grantPrivilegesAttr, privilegesSet)
 			break
 		}
+
+		log.Printf("[DEBUG] Collected table grants; table: '%v'; privileges: %v; for: %s", objName, privilegesSet.List(), entityName)
 	}
-	log.Printf("[DEBUG] Collected table grants")
 
 	return nil
 }

--- a/redshift/resource_redshift_grant.go
+++ b/redshift/resource_redshift_grant.go
@@ -68,7 +68,7 @@ Defines access privileges for users and  groups. Privileges include access optio
 				Optional:     true,
 				ForceNew:     true,
 				ExactlyOneOf: []string{grantUserAttr, grantGroupAttr},
-				Description:  "The name of the group to grant privileges on. Either `group` or `user` parameter must be set.",
+				Description:  "The name of the group to grant privileges on. Either `group` or `user` parameter must be set. Settings the group name to `public` will result in a `GRANT ... TO PUBLIC` statement.",
 			},
 			grantSchemaAttr: {
 				Type:        schema.TypeString,

--- a/redshift/resource_redshift_grant.go
+++ b/redshift/resource_redshift_grant.go
@@ -247,8 +247,8 @@ func readDatabaseGrants(db *DBConnection, d *schema.ResourceData) error {
 	if isGrantToPublic(d) {
 		query = `
   SELECT
-    decode(charindex('C',split_part(split_part(regexp_replace(replace(array_to_string(db.datacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0,0,1) as create,
-    decode(charindex('T',split_part(split_part(regexp_replace(replace(array_to_string(db.datacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0,0,1) as temporary
+    decode(charindex('C',split_part(split_part(regexp_replace(replace(array_to_string(db.datacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0,0,1) as create,
+    decode(charindex('T',split_part(split_part(regexp_replace(replace(array_to_string(db.datacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0,0,1) as temporary
   FROM pg_database db
   WHERE
     db.datname=$1 
@@ -308,8 +308,8 @@ func readSchemaGrants(db *DBConnection, d *schema.ResourceData) error {
 	if isGrantToPublic(d) {
 		query = `
 			SELECT
-				decode(charindex('C',split_part(split_part(regexp_replace(replace(array_to_string(ns.nspacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0,0,1) as create,
-				decode(charindex('U',split_part(split_part(regexp_replace(replace(array_to_string(ns.nspacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0,0,1) as usage
+				decode(charindex('C',split_part(split_part(regexp_replace(replace(array_to_string(ns.nspacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0,0,1) as create,
+				decode(charindex('U',split_part(split_part(regexp_replace(replace(array_to_string(ns.nspacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0,0,1) as usage
 			FROM pg_namespace ns
 			WHERE
 				ns.nspname=$1
@@ -389,14 +389,14 @@ func readTableGrants(db *DBConnection, d *schema.ResourceData) error {
 		query = `
 		SELECT
 		  relname,
-		  decode(charindex('r',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as select,
-		  decode(charindex('w',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as update,
-		  decode(charindex('a',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as insert,
-		  decode(charindex('d',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as delete,
-		  decode(charindex('D',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as drop,
-		  decode(charindex('x',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as references,
-		  decode(charindex('R',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as rule,
-		  decode(charindex('t',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as trigger
+		  decode(charindex('r',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as select,
+		  decode(charindex('w',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as update,
+		  decode(charindex('a',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as insert,
+		  decode(charindex('d',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as delete,
+		  decode(charindex('D',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as drop,
+		  decode(charindex('x',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as references,
+		  decode(charindex('R',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as rule,
+		  decode(charindex('t',split_part(split_part(regexp_replace(replace(array_to_string(relacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)),null,0,0,0,1) as trigger
 		FROM pg_class cl
 		JOIN pg_namespace nsp ON nsp.oid = cl.relnamespace
 		WHERE
@@ -511,7 +511,7 @@ func readCallableGrants(db *DBConnection, d *schema.ResourceData) error {
 		query = `
 	SELECT
 		proname,
-		decode(nvl(charindex('X',split_part(split_part(regexp_replace(replace(array_to_string(pr.proacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0), 0,0,1) as execute
+		decode(nvl(charindex('X',split_part(split_part(regexp_replace(replace(array_to_string(pr.proacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0), 0,0,1) as execute
 	FROM pg_proc_info pr
 		JOIN pg_namespace nsp ON nsp.oid = pr.pronamespace
 	WHERE
@@ -599,7 +599,7 @@ func readLanguageGrants(db *DBConnection, d *schema.ResourceData) error {
 		query = `
 		SELECT
 			  lanname,
-		  decode(nvl(charindex('U',split_part(split_part(regexp_replace(replace(array_to_string(lg.lanacl, '|'), '"', ''),'[^|+]=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0), 0,0,1) as usage
+		  decode(nvl(charindex('U',split_part(split_part(regexp_replace(replace(array_to_string(lg.lanacl, '|'), '"', ''),'[^|]+=','__avoidUserPrivs__'), '=', 2) ,'/',1)), 0), 0,0,1) as usage
 		FROM pg_language lg
 	  `
 		queryArgs = []interface{}{}

--- a/redshift/resource_redshift_grant_test.go
+++ b/redshift/resource_redshift_grant_test.go
@@ -19,7 +19,7 @@ resource "redshift_schema" "test" {
 }
 
 resource "redshift_grant" "public" {
-	group = "public"
+	group = "PUBLIC"
 
 	schema = %[1]q
 	object_type = "schema"

--- a/redshift/resource_redshift_grant_test.go
+++ b/redshift/resource_redshift_grant_test.go
@@ -102,6 +102,46 @@ resource "redshift_grant" "public" {
 	})
 }
 
+func TestAccRedshiftGrant_TableToPublic(t *testing.T) {
+	config := `
+resource "redshift_grant" "public" {
+	group = "public"
+
+	schema = "pg_catalog"
+	object_type = "table"
+	objects = ["pg_user_info"]
+	privileges = ["select", "update", "insert", "delete", "drop", "references", "rule", "trigger"]
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: func(s *terraform.State) error { return nil },
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("redshift_grant.public", "id", "gn:public_ot:table_pg_catalog_pg_user_info"),
+					resource.TestCheckResourceAttr("redshift_grant.public", "group", "public"),
+					resource.TestCheckResourceAttr("redshift_grant.public", "schema", "pg_catalog"),
+					resource.TestCheckResourceAttr("redshift_grant.public", "object_type", "table"),
+					resource.TestCheckResourceAttr("redshift_grant.public", "objects.#", "1"),
+					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "objects.*", "pg_user_info"),
+					resource.TestCheckResourceAttr("redshift_grant.public", "privileges.#", "8"),
+					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "select"),
+					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "update"),
+					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "insert"),
+					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "delete"),
+					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "drop"),
+					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "references"),
+					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "rule"),
+					resource.TestCheckTypeSetElemAttr("redshift_grant.public", "privileges.*", "trigger"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRedshiftGrant_BasicDatabase(t *testing.T) {
 	groupNames := []string{
 		strings.ReplaceAll(acctest.RandomWithPrefix("tf_acc_group"), "-", "_"),

--- a/redshift/resource_redshift_schema_test.go
+++ b/redshift/resource_redshift_schema_test.go
@@ -151,8 +151,9 @@ resource "redshift_user" "schema_dl_user1" {
 
 // Acceptance test for external redshift schema using AWS Glue Data Catalog
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_IAM_ROLE_ARNS - comma-separated list of ARNs to use
 func TestAccRedshiftSchema_ExternalDataCatalog(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_DATABASE", t)
 	iamRoleArnsRaw := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_DATA_CATALOG_IAM_ROLE_ARNS", t)
@@ -207,11 +208,14 @@ resource "redshift_schema" "spectrum" {
 
 // Acceptance test for external redshift schema using Hive metastore
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME - hive metastore database endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME - hive metastore database endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_HIVE_PORT - hive metastore port. Default is 9083
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_HIVE_PORT - hive metastore port. Default is 9083
 func TestAccRedshiftSchema_ExternalHive(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_HIVE_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_HIVE_HOSTNAME", t)
@@ -275,13 +279,16 @@ resource "redshift_schema" "hive" {
 
 // Acceptance test for external redshift schema using RDS Postgres
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME - RDS endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_IAM_ROLE_ARNS - comma-separated list of ARNs to use
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME - RDS endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_PORT - RDS port. Default is 5432
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SCHEMA - source database schema. Default is "public"
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_PORT - RDS port. Default is 5432
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_SCHEMA - source database schema. Default is "public"
 func TestAccRedshiftSchema_ExternalRdsPostgres(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_POSTGRES_HOSTNAME", t)
@@ -354,12 +361,15 @@ resource "redshift_schema" "postgres" {
 
 // Acceptance test for external redshift schema using RDS Mysql
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE - source database name
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME - RDS endpoint FQDN or IP address
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_IAM_ROLE_ARNS - comma-separated list of ARNs to use
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE - source database name
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME - RDS endpoint FQDN or IP address
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_IAM_ROLE_ARNS - comma-separated list of ARNs to use
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_SECRET_ARN - ARN of the secret in Secrets Manager containing credentials for authenticating to RDS
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_PORT - RDS port. Default is 3306
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_PORT - RDS port. Default is 3306
 func TestAccRedshiftSchema_ExternalRdsMysql(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_DATABASE", t)
 	dbHostname := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_RDS_MYSQL_HOSTNAME", t)
@@ -426,9 +436,12 @@ resource "redshift_schema" "mysql" {
 
 // Acceptance test for external redshift schema using datashare database
 // The following environment variables must be set, otherwise the test will be skipped:
-//   REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE - source database name
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE - source database name
+//
 // Additionally, the following environment variables may be optionally set:
-//   REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA - datashare schema name. Default is "public"
+//
+//	REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA - datashare schema name. Default is "public"
 func TestAccRedshiftSchema_ExternalRedshift(t *testing.T) {
 	dbName := getEnvOrSkip("REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_DATABASE", t)
 	dbSchema := os.Getenv("REDSHIFT_EXTERNAL_SCHEMA_REDSHIFT_SCHEMA")


### PR DESCRIPTION
The PR adds implementation of `GRANT ... TO PUBLIC`. Example usage in resource:

```
resource "redshift_grant" "public" {
  group = "public"

  schema      = "my_schema"
  object_type = "schema"
  privileges  = ["create", "usage"]
}
```

Fixes #61 