### PR TITLE
Fix #113 Allow setting of a AWS profile when creating the SDK config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,7 @@ Optional:
 - **db_groups** (Set of String) A list of the names of existing database groups that the user will join for the current session, in addition to any group memberships for an existing user. If not specified, a new user is added only to PUBLIC.
 - **duration_seconds** (Number) The number of seconds until the returned temporary password expires.
 - **region** (String) The AWS region where the Redshift cluster is located.
+- **profile** (String) The AWS profile to use when requesting temporary credentials.
 
 <a id="nestedblock--temporary_credentials--assume_role"></a>
 ### Nested Schema for `temporary_credentials.assume_role`

--- a/redshift/provider.go
+++ b/redshift/provider.go
@@ -98,6 +98,11 @@ func Provider() *schema.Provider {
 							Optional:    true,
 							Description: "The AWS region where the Redshift cluster is located.",
 						},
+						"profile": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The AWS profile to use when requesting temporary credentials.",
+						},
 						"auto_create_user": {
 							Type:        schema.TypeBool,
 							Optional:    true,
@@ -232,7 +237,13 @@ func temporaryCredentials(username string, d *schema.ResourceData) (string, stri
 }
 
 func redshiftSdkClient(d *schema.ResourceData) (*redshift.Client, error) {
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+	loadOptions := []func(*config.LoadOptions) error{}
+
+	if profile := d.Get("temporary_credentials.0.profile").(string); profile != "" {
+		loadOptions = append(loadOptions, config.WithSharedConfigProfile(profile))
+	}
+
+	cfg, err := config.LoadDefaultConfig(context.TODO(), loadOptions...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When working with many AWS accounts you need to be able to specify different profiles when connecting to given services.

Currently this plugin does not allow the setting of a profile which means you need to remember to run Terraform with `AWS_PROFILE=customprofile terraform plan` or the `GetClusterCredentials` call will fail.

If you are using the AWS provider, running Terraform with the `AWS_PROFILE` overrides any explicitly defined profile on the provider.
This means when using profiles, under some conditions, you cannot use this provider and the AWS provider in the same project.

This PR adds the option to define a profile which is completely optional. If no profile is defined the provider operates in the same way as it did before.